### PR TITLE
rework pipeline API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           key: tests-bookworm-1.93-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: tests-bookworm-1.93-cargo-
       - name: Run tests
-        run: cargo test --workspace --features serde --locked
+        run: cargo test --workspace --features serde,derive --locked
   cargo-fmt:
     runs-on: ubuntu-latest
     container: rust:1.93.1-bookworm 

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,5 +1,5 @@
-use quote::quote;
-use syn::{DeriveInput, parse_macro_input};
+use quote::{ToTokens, quote};
+use syn::{DeriveInput, Type, parse_macro_input};
 
 extern crate proc_macro;
 
@@ -67,6 +67,67 @@ pub fn derive_uniform_block(input: proc_macro::TokenStream) -> proc_macro::Token
             const FIELDS: &'static [mimiq::graphics::UniformField] = &[
                 #(#field_invocations),*
             ];
+        }
+    };
+
+    output.into()
+}
+
+#[proc_macro_derive(ImagesUniformBlock)]
+pub fn derive_images_block(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let input = parse_macro_input!(input as DeriveInput);
+    let DeriveInput { ident, data, .. } = input;
+    let syn::Data::Struct(fields) = data else {
+        return quote! {
+            compile_error!("Only structs are supported");
+        }
+        .into();
+    };
+
+    let field_names = fields
+        .fields
+        .iter()
+        .map(|field| match &field.ident {
+            None => quote! {
+                compile_error!("Unit structs are not supported");
+            },
+            Some(field_name) => field_name.into_token_stream(),
+        })
+        .collect::<Vec<_>>();
+    let field_invocations = fields
+        .fields
+        .iter()
+        .map(|field| match &field.ident {
+            None => quote! {
+                compile_error!("Unit structs are not supported");
+            },
+            Some(field_name) => match &field.ty {
+                Type::Reference(ty_ref) => {
+                    let field_type = &ty_ref.elem;
+                    quote! {
+                        mimiq::image_uniform_of!(#field_type, #field_name)
+                    }
+                }
+                _ => quote! {
+                    compile_error!("Only reference type fields are allowed");
+                },
+            },
+        })
+        .collect::<Vec<_>>();
+    let slots = 0..(field_invocations.len() as u32);
+
+    let output = quote! {
+        impl mimiq::graphics::ImagesUniformBlock for #ident<'_> {
+            type Borrow<'a> = &'a #ident<'a>;
+
+            const FIELDS: &'static [mimiq::graphics::ImageUniformField] = &[
+                #(#field_invocations),*
+            ];
+
+            fn bind(borrow: Self::Borrow<'_>) {
+                use mimiq::graphics::ImageUniformVal;
+                #( borrow.#field_names.bind(#slots) );*
+            }
         }
     };
 

--- a/examples/basic_img.rs
+++ b/examples/basic_img.rs
@@ -19,7 +19,7 @@ struct App {
     total_time: Duration,
     ctx: Rc<GlContext>,
 
-    pipeline: Pipeline<Meta>,
+    pipeline: Pipeline<ImgVertex, Uniforms, ImageImages<'static>>,
     vertices: VertexBuffer<ImgVertex>,
     indicies: IndexBuffer,
     texture: Option<Texture2D>,
@@ -67,7 +67,18 @@ impl EventHandler<()> for App {
             0, 2, 3,
         ]);
 
-        let pipeline = ctx.new_pipeline();
+        let pipeline = ctx.new_pipeline(
+            include_str!("shaders/with_offset.vert"),
+            include_str!("shaders/basic_texture.frag"),
+            PipelineParams {
+                blending: Blending::All(BlendFunc {
+                    equation: BlendEquation::Add,
+                    source: BlendFactor::Value(BlendValue::SrcAlpha),
+                    dest: BlendFactor::OneMinusValue(BlendValue::SrcAlpha),
+                }),
+                ..default_pipeline_params()
+            },
+        );
 
         App { pipeline, vertices, indicies, texture: None, ctx, total_time: Duration::ZERO }
     }
@@ -77,7 +88,7 @@ impl App {
     fn draw(&mut self) {
         let t = self.total_time.as_secs_f32();
 
-        let Some(texture) = self.texture.as_ref() else {
+        let Some(tex) = self.texture.as_ref() else {
             return;
         };
 
@@ -85,15 +96,14 @@ impl App {
             .default_pass(Clear::depth_color(Color::BLACK), |_, _| {
                 for i in 0..10 {
                     let t = t + i as f32 * 0.3;
-                    self.ctx.draw(DrawCall {
-                        pipeline: &self.pipeline,
-                        base_element: 0,
-                        num_elements: 6,
-                        vertex_buffer: &self.vertices,
-                        index_buffer: &self.indicies,
-                        images: &texture,
-                        uniforms: &Uniforms { offset: vec2(t.sin() * 0.5, (t * 3.).cos() * 0.5) },
-                    });
+                    self.pipeline.draw(
+                        0,
+                        6,
+                        &self.vertices,
+                        &self.indicies,
+                        &ImageImages { tex },
+                        &Uniforms { offset: vec2(t.sin() * 0.5, (t * 3.).cos() * 0.5) },
+                    );
                 }
             });
     }
@@ -106,28 +116,13 @@ pub struct ImgVertex {
     v_uv: Vec2,
 }
 
-pub struct Meta;
-
-impl PipelineMeta for Meta {
-    const VERTEX_SHADER: &str = include_str!("shaders/with_offset.vert");
-    const FRAGMENT_SHADER: &str = include_str!("shaders/basic_texture.frag");
-
-    const IMAGES_NAMES: &str = "tex";
-    type Images = Texture2D;
-    type Vertex = ImgVertex;
-    type Uniforms = Uniforms;
-    const PARAMS: PipelineParams = PipelineParams {
-        blending: Blending::All(BlendFunc {
-            equation: BlendEquation::Add,
-            source: BlendFactor::Value(BlendValue::SrcAlpha),
-            dest: BlendFactor::OneMinusValue(BlendValue::SrcAlpha),
-        }),
-        ..default_pipeline_params()
-    };
-}
-
 #[repr(C)]
 #[derive(Debug, Zeroable, Pod, Clone, Copy, UniformBlock)]
 pub struct Uniforms {
     pub offset: Vec2,
+}
+
+#[derive(Debug, Clone, Copy, ImagesUniformBlock)]
+pub struct ImageImages<'a> {
+    pub tex: &'a Texture2D,
 }

--- a/examples/batcher.rs
+++ b/examples/batcher.rs
@@ -19,7 +19,7 @@ fn main() {
 
 struct App {
     total_time: Duration,
-    pipeline: Pipeline<Meta>,
+    pipeline: Pipeline<BasicVertex>,
     batcher: GeometryBatcher<BasicVertex>,
     ctx: Rc<GlContext>,
 }
@@ -38,7 +38,11 @@ impl EventHandler<()> for App {
 
     fn init(ctx: Rc<GlContext>, _fs: Rc<dyn FsServer>, _init: ()) -> App {
         let batcher = GeometryBatcher::new_from_size(&ctx, 50, 50);
-        let pipeline = ctx.new_pipeline();
+        let pipeline = ctx.new_pipeline(
+            include_str!("shaders/basic_vert.vert"),
+            include_str!("shaders/basic_color.frag"),
+            default_pipeline_params(),
+        );
 
         App { pipeline, batcher, ctx, total_time: Duration::ZERO }
     }
@@ -82,28 +86,14 @@ impl App {
 
         self.ctx
             .default_pass(Clear::depth_color(Color::BLACK), |_, _| {
-                self.ctx.draw(DrawCall {
-                    pipeline: &self.pipeline,
-                    base_element: 0,
+                self.pipeline.draw(
+                    0,
                     num_elements,
-                    vertex_buffer: &self.batcher.vertices,
-                    index_buffer: &self.batcher.indicies,
-                    images: &NoImages,
-                    uniforms: &NoUniforms,
-                });
+                    &self.batcher.vertices,
+                    &self.batcher.indicies,
+                    &NoImages,
+                    &NoUniforms,
+                );
             });
     }
-}
-
-pub struct Meta;
-
-impl PipelineMeta for Meta {
-    const VERTEX_SHADER: &str = include_str!("shaders/basic_vert.vert");
-    const FRAGMENT_SHADER: &str = include_str!("shaders/basic_color.frag");
-
-    const IMAGES_NAMES: () = ();
-    type Images = NoImages;
-    type Vertex = util::BasicVertex;
-    type Uniforms = NoUniforms;
-    const PARAMS: PipelineParams = default_pipeline_params();
 }

--- a/examples/blobs.rs
+++ b/examples/blobs.rs
@@ -19,7 +19,7 @@ fn main() {
 
 struct App {
     mouse_pos: Vec2,
-    pipeline: Pipeline<Meta>,
+    pipeline: Pipeline<BlobVertex, Uniforms>,
     vertices: VertexBuffer<BlobVertex>,
     indicies: IndexBuffer,
     uniforms: Uniforms,
@@ -76,7 +76,12 @@ impl EventHandler<()> for App {
             0, 2, 3,
         ]);
 
-        let pipeline = ctx.new_pipeline();
+        // based on: https://www.shadertoy.com/view/XsS3DV
+        let pipeline = ctx.new_pipeline(
+            include_str!("shaders/basic_texture.vert"),
+            include_str!("shaders/blobs.frag"),
+            default_pipeline_params(),
+        );
 
         let uniforms = Uniforms { time: 0., blobs_count: 1, blobs_positions: [vec2(0., 0.); 32] };
 
@@ -123,15 +128,14 @@ impl App {
         self.uniforms.time = self.total_time.as_secs_f32();
         self.ctx
             .default_pass(Clear::depth_color(Color::BLACK), |_, _| {
-                self.ctx.draw(DrawCall {
-                    pipeline: &self.pipeline,
-                    base_element: 0,
-                    num_elements: 6,
-                    vertex_buffer: &self.vertices,
-                    index_buffer: &self.indicies,
-                    images: &NoImages,
-                    uniforms: &self.uniforms,
-                });
+                self.pipeline.draw(
+                    0,
+                    6,
+                    &self.vertices,
+                    &self.indicies,
+                    &NoImages,
+                    &self.uniforms,
+                );
             });
     }
 }
@@ -141,20 +145,6 @@ impl App {
 pub struct BlobVertex {
     pub v_pos: Vec2,
     pub v_uv: Vec2,
-}
-
-// based on: https://www.shadertoy.com/view/XsS3DV
-pub struct Meta;
-
-impl PipelineMeta for Meta {
-    const VERTEX_SHADER: &str = include_str!("shaders/basic_texture.vert");
-    const FRAGMENT_SHADER: &str = include_str!("shaders/blobs.frag");
-
-    const IMAGES_NAMES: () = ();
-    type Images = NoImages;
-    type Vertex = BlobVertex;
-    type Uniforms = Uniforms;
-    const PARAMS: PipelineParams = default_pipeline_params();
 }
 
 #[repr(C)]

--- a/examples/egui.rs
+++ b/examples/egui.rs
@@ -19,7 +19,7 @@ struct App {
     total_time: Duration,
     ctx: Rc<GlContext>,
 
-    pipeline: Pipeline<Meta>,
+    pipeline: Pipeline<ImgVertex, Uniforms, ImageImages<'static>>,
     vertices: VertexBuffer<ImgVertex>,
     indicies: IndexBuffer,
     texture: Option<Texture2D>,
@@ -82,7 +82,18 @@ impl EventHandler<()> for App {
             0, 2, 3,
         ]);
 
-        let pipeline = ctx.new_pipeline();
+        let pipeline = ctx.new_pipeline(
+            include_str!("shaders/with_offset.vert"),
+            include_str!("shaders/basic_texture.frag"),
+            PipelineParams {
+                blending: Blending::All(BlendFunc {
+                    equation: BlendEquation::Add,
+                    source: BlendFactor::Value(BlendValue::SrcAlpha),
+                    dest: BlendFactor::OneMinusValue(BlendValue::SrcAlpha),
+                }),
+                ..default_pipeline_params()
+            },
+        );
 
         App { pipeline, vertices, indicies, texture: None, ctx, total_time: Duration::ZERO }
     }
@@ -92,7 +103,7 @@ impl App {
     fn draw(&mut self) {
         let t = self.total_time.as_secs_f32();
 
-        let Some(texture) = self.texture.as_ref() else {
+        let Some(tex) = self.texture.as_ref() else {
             return;
         };
 
@@ -100,15 +111,14 @@ impl App {
             .default_pass(Clear::depth_color(Color::BLACK), |_, _| {
                 for i in 0..10 {
                     let t = t + i as f32 * 0.3;
-                    self.ctx.draw(DrawCall {
-                        pipeline: &self.pipeline,
-                        base_element: 0,
-                        num_elements: 6,
-                        vertex_buffer: &self.vertices,
-                        index_buffer: &self.indicies,
-                        images: &texture,
-                        uniforms: &Uniforms { offset: vec2(t.sin() * 0.5, (t * 3.).cos() * 0.5) },
-                    });
+                    self.pipeline.draw(
+                        0,
+                        6,
+                        &self.vertices,
+                        &self.indicies,
+                        &ImageImages { tex },
+                        &Uniforms { offset: vec2(t.sin() * 0.5, (t * 3.).cos() * 0.5) },
+                    );
                 }
             });
     }
@@ -121,28 +131,13 @@ pub struct ImgVertex {
     v_uv: Vec2,
 }
 
-pub struct Meta;
-
-impl PipelineMeta for Meta {
-    const VERTEX_SHADER: &str = include_str!("shaders/with_offset.vert");
-    const FRAGMENT_SHADER: &str = include_str!("shaders/basic_texture.frag");
-
-    const IMAGES_NAMES: &str = "tex";
-    type Images = Texture2D;
-    type Vertex = ImgVertex;
-    type Uniforms = Uniforms;
-    const PARAMS: PipelineParams = PipelineParams {
-        blending: Blending::All(BlendFunc {
-            equation: BlendEquation::Add,
-            source: BlendFactor::Value(BlendValue::SrcAlpha),
-            dest: BlendFactor::OneMinusValue(BlendValue::SrcAlpha),
-        }),
-        ..default_pipeline_params()
-    };
-}
-
 #[repr(C)]
 #[derive(Debug, Zeroable, Pod, Clone, Copy, UniformBlock)]
 pub struct Uniforms {
     pub offset: Vec2,
+}
+
+#[derive(Debug, Clone, Copy, ImagesUniformBlock)]
+pub struct ImageImages<'a> {
+    pub tex: &'a Texture2D,
 }

--- a/examples/offscreen.rs
+++ b/examples/offscreen.rs
@@ -19,8 +19,8 @@ struct App {
     vertices_display_cube: VertexBuffer<CubeDisplayVert>,
     vertices_cube: VertexBuffer<CubeVert>,
     indicies_cube: IndexBuffer,
-    display_pipeline: Pipeline<DisplayMeta>,
-    offscreen_pipeline: Pipeline<OffscreenMeta>,
+    display_pipeline: Pipeline<CubeDisplayVert, Uniforms, DisplayImages<'static>>,
+    offscreen_pipeline: Pipeline<CubeVert, Uniforms>,
     offscreen_pass: RenderPass,
     rx: f32,
     ry: f32,
@@ -110,8 +110,22 @@ impl EventHandler<()> for App {
             22, 21, 20,  23, 22, 20
         ]);
 
-        let display_pipeline = ctx.new_pipeline();
-        let offscreen_pipeline = ctx.new_pipeline();
+        let display_pipeline = ctx.new_pipeline(
+            include_str!("shaders/mvp_color_texture.vert"),
+            include_str!("shaders/color_texture.frag"),
+            PipelineParams {
+                depth_test: Some(Comparison::LessOrEqual),
+                ..default_pipeline_params()
+            },
+        );
+        let offscreen_pipeline = ctx.new_pipeline(
+            include_str!("shaders/mvp_color.vert"),
+            include_str!("shaders/basic_color.frag"),
+            PipelineParams {
+                depth_test: Some(Comparison::LessOrEqual),
+                ..default_pipeline_params()
+            },
+        );
 
         App {
             vertices_cube,
@@ -143,30 +157,28 @@ impl App {
         // the offscreen pass, rendering a rotating, untextured cube into a render target image
         self.offscreen_pass
             .pass(Clear::depth_color(Color::WHITE), |_, _| {
-                self.ctx.draw(DrawCall {
-                    pipeline: &self.offscreen_pipeline,
-                    base_element: 0,
-                    num_elements: 36,
-                    vertex_buffer: &self.vertices_cube,
-                    index_buffer: &self.indicies_cube,
-                    images: &NoImages,
-                    uniforms: &Uniforms { mvp: view_proj * model },
-                });
+                self.offscreen_pipeline.draw(
+                    0,
+                    36,
+                    &self.vertices_cube,
+                    &self.indicies_cube,
+                    &NoImages,
+                    &Uniforms { mvp: view_proj * model },
+                );
             });
 
         // and the display-pass, rendering a rotating, textured cube, using the
         // previously rendered offscreen render-target as texture
         self.ctx
             .default_pass(Clear::depth_color(Color::DARKBLUE), |_, _| {
-                self.ctx.draw(DrawCall {
-                    pipeline: &self.display_pipeline,
-                    base_element: 0,
-                    num_elements: 36,
-                    vertex_buffer: &self.vertices_display_cube,
-                    index_buffer: &self.indicies_cube,
-                    images: &self.offscreen_pass.color_attachments()[0],
-                    uniforms: &Uniforms { mvp: view_proj * model },
-                });
+                self.display_pipeline.draw(
+                    0,
+                    36,
+                    &self.vertices_display_cube,
+                    &self.indicies_cube,
+                    &DisplayImages { tex: &self.offscreen_pass.color_attachments()[0] },
+                    &Uniforms { mvp: view_proj * model },
+                );
             });
     }
 }
@@ -186,32 +198,9 @@ pub struct CubeDisplayVert {
     pub v_uv: Vec2,
 }
 
-pub struct DisplayMeta;
-
-impl PipelineMeta for DisplayMeta {
-    const VERTEX_SHADER: &str = include_str!("shaders/mvp_color_texture.vert");
-    const FRAGMENT_SHADER: &str = include_str!("shaders/color_texture.frag");
-
-    const IMAGES_NAMES: &str = "tex";
-    type Images = Texture2D;
-    type Vertex = CubeDisplayVert;
-    type Uniforms = Uniforms;
-    const PARAMS: PipelineParams =
-        PipelineParams { depth_test: Some(Comparison::LessOrEqual), ..default_pipeline_params() };
-}
-
-pub struct OffscreenMeta;
-
-impl PipelineMeta for OffscreenMeta {
-    const VERTEX_SHADER: &str = include_str!("shaders/mvp_color.vert");
-    const FRAGMENT_SHADER: &str = include_str!("shaders/basic_color.frag");
-
-    const IMAGES_NAMES: () = ();
-    type Images = NoImages;
-    type Vertex = CubeVert;
-    type Uniforms = Uniforms;
-    const PARAMS: PipelineParams =
-        PipelineParams { depth_test: Some(Comparison::LessOrEqual), ..default_pipeline_params() };
+#[derive(Debug, Clone, Copy, ImagesUniformBlock)]
+pub struct DisplayImages<'a> {
+    pub tex: &'a Texture2D,
 }
 
 #[repr(C)]

--- a/examples/post_processing.rs
+++ b/examples/post_processing.rs
@@ -20,8 +20,9 @@ struct App {
     indicies_cube: IndexBuffer,
     vertices_quad: VertexBuffer<QuadVert>,
     indicies_quad: IndexBuffer,
-    post_processing_pipeline: Pipeline<PostProcessingMeta>,
-    offscreen_pipeline: Pipeline<OffscreenMeta>,
+    post_processing_pipeline:
+        Pipeline<QuadVert, PostProcessingUniforms, PostProcessingImages<'static>>,
+    offscreen_pipeline: Pipeline<CubeVert, OffscreenUniforms>,
     offscreen_pass: RenderPass,
     rx: f32,
     ry: f32,
@@ -121,8 +122,19 @@ impl EventHandler<()> for App {
             0, 2, 3,
         ]);
 
-        let post_processing_pipeline = ctx.new_pipeline();
-        let offscreen_pipeline = ctx.new_pipeline();
+        let post_processing_pipeline = ctx.new_pipeline(
+            include_str!("shaders/basic_texture.vert"),
+            include_str!("shaders/gaus_blur.frag"),
+            default_pipeline_params(),
+        );
+        let offscreen_pipeline = ctx.new_pipeline(
+            include_str!("shaders/mvp_color.vert"),
+            include_str!("shaders/basic_color.frag"),
+            PipelineParams {
+                depth_test: Some(Comparison::LessOrEqual),
+                ..default_pipeline_params()
+            },
+        );
 
         App {
             vertices_cube,
@@ -177,30 +189,28 @@ impl App {
         // the offscreen pass, rendering an rotating, untextured cube into a render target image
         self.offscreen_pass
             .pass(Clear::depth_color(Color::WHITE), |_, _| {
-                self.ctx.draw(DrawCall {
-                    pipeline: &self.offscreen_pipeline,
-                    base_element: 0,
-                    num_elements: 36,
-                    vertex_buffer: &self.vertices_cube,
-                    index_buffer: &self.indicies_cube,
-                    images: &NoImages,
-                    uniforms: &OffscreenUniforms { mvp: view_proj * model },
-                });
+                self.offscreen_pipeline.draw(
+                    0,
+                    36,
+                    &self.vertices_cube,
+                    &self.indicies_cube,
+                    &NoImages,
+                    &OffscreenUniforms { mvp: view_proj * model },
+                );
             });
 
         // and the post-processing-pass, rendering a rotating, textured cube, using the
         // previously rendered offscreen render-target as texture
         self.ctx
             .default_pass(Clear::depth_color(Color::WHITE), |_, _| {
-                self.ctx.draw(DrawCall {
-                    pipeline: &self.post_processing_pipeline,
-                    base_element: 0,
-                    num_elements: 6,
-                    vertex_buffer: &self.vertices_quad,
-                    index_buffer: &self.indicies_quad,
-                    images: &self.offscreen_pass.color_attachments()[0],
-                    uniforms: &PostProcessingUniforms { resolution: vec2(width, height) },
-                });
+                self.post_processing_pipeline.draw(
+                    0,
+                    6,
+                    &self.vertices_quad,
+                    &self.indicies_quad,
+                    &PostProcessingImages { tex: &self.offscreen_pass.color_attachments()[0] },
+                    &PostProcessingUniforms { resolution: vec2(width, height) },
+                );
             });
     }
 }
@@ -219,37 +229,15 @@ pub struct QuadVert {
     pub v_uv: Vec2,
 }
 
-pub struct PostProcessingMeta;
-
-impl PipelineMeta for PostProcessingMeta {
-    const VERTEX_SHADER: &str = include_str!("shaders/basic_texture.vert");
-    const FRAGMENT_SHADER: &str = include_str!("shaders/gaus_blur.frag");
-
-    const IMAGES_NAMES: &str = "tex";
-    type Images = Texture2D;
-    type Vertex = QuadVert;
-    type Uniforms = PostProcessingUniforms;
-    const PARAMS: PipelineParams = default_pipeline_params();
+#[derive(Debug, Clone, Copy, ImagesUniformBlock)]
+pub struct PostProcessingImages<'a> {
+    pub tex: &'a Texture2D,
 }
 
 #[repr(C)]
 #[derive(Debug, Pod, Zeroable, Clone, Copy, UniformBlock)]
 pub struct PostProcessingUniforms {
     pub resolution: glam::Vec2,
-}
-
-pub struct OffscreenMeta;
-
-impl PipelineMeta for OffscreenMeta {
-    const VERTEX_SHADER: &str = include_str!("shaders/mvp_color.vert");
-    const FRAGMENT_SHADER: &str = include_str!("shaders/basic_color.frag");
-
-    const IMAGES_NAMES: () = ();
-    type Images = NoImages;
-    type Vertex = CubeVert;
-    type Uniforms = OffscreenUniforms;
-    const PARAMS: PipelineParams =
-        PipelineParams { depth_test: Some(Comparison::LessOrEqual), ..default_pipeline_params() };
 }
 
 #[repr(C)]

--- a/examples/quad.rs
+++ b/examples/quad.rs
@@ -20,7 +20,7 @@ struct App {
     total_time: Duration,
     ctx: Rc<GlContext>,
 
-    pipeline: Pipeline<Meta>,
+    pipeline: Pipeline<ImgVertex, Uniforms, ImageImages<'static>>,
     vertices: VertexBuffer<ImgVertex>,
     indicies: IndexBuffer,
     texture: Texture2D,
@@ -61,7 +61,18 @@ impl EventHandler<()> for App {
             FilterMode::Linear,
         );
 
-        let pipeline = ctx.new_pipeline();
+        let pipeline = ctx.new_pipeline(
+            include_str!("shaders/with_offset.vert"),
+            include_str!("shaders/basic_texture.frag"),
+            PipelineParams {
+                blending: Blending::All(BlendFunc {
+                    equation: BlendEquation::Add,
+                    source: BlendFactor::Value(BlendValue::SrcAlpha),
+                    dest: BlendFactor::OneMinusValue(BlendValue::SrcAlpha),
+                }),
+                ..default_pipeline_params()
+            },
+        );
 
         App { pipeline, vertices, indicies, texture, ctx, total_time: Duration::ZERO }
     }
@@ -75,15 +86,14 @@ impl App {
             .default_pass(Clear::depth_color(Color::BLACK), |_, _| {
                 for i in 0..10 {
                     let t = t + i as f32 * 0.3;
-                    self.ctx.draw(DrawCall {
-                        pipeline: &self.pipeline,
-                        base_element: 0,
-                        num_elements: 6,
-                        vertex_buffer: &self.vertices,
-                        index_buffer: &self.indicies,
-                        images: &self.texture,
-                        uniforms: &Uniforms { offset: vec2(t.sin() * 0.5, (t * 3.).cos() * 0.5) },
-                    });
+                    self.pipeline.draw(
+                        0,
+                        6,
+                        &self.vertices,
+                        &self.indicies,
+                        &ImageImages { tex: &self.texture },
+                        &Uniforms { offset: vec2(t.sin() * 0.5, (t * 3.).cos() * 0.5) },
+                    );
                 }
             });
     }
@@ -96,24 +106,9 @@ pub struct ImgVertex {
     pub v_uv: Vec2,
 }
 
-pub struct Meta;
-
-impl PipelineMeta for Meta {
-    const VERTEX_SHADER: &str = include_str!("shaders/with_offset.vert");
-    const FRAGMENT_SHADER: &str = include_str!("shaders/basic_texture.frag");
-
-    const IMAGES_NAMES: &str = "tex";
-    type Images = Texture2D;
-    type Vertex = ImgVertex;
-    type Uniforms = Uniforms;
-    const PARAMS: PipelineParams = PipelineParams {
-        blending: Blending::All(BlendFunc {
-            equation: BlendEquation::Add,
-            source: BlendFactor::Value(BlendValue::SrcAlpha),
-            dest: BlendFactor::OneMinusValue(BlendValue::SrcAlpha),
-        }),
-        ..default_pipeline_params()
-    };
+#[derive(Debug, Clone, Copy, ImagesUniformBlock)]
+pub struct ImageImages<'a> {
+    pub tex: &'a Texture2D,
 }
 
 #[repr(C)]

--- a/examples/shaders/blobs.frag
+++ b/examples/shaders/blobs.frag
@@ -4,7 +4,7 @@ uniform vec2 blobs_positions[32];
 
 in vec2 f_uv;
 
-out vec4 o_color;
+layout(location = 0) out vec4 o_color;
 
 float k = 20.0;
 

--- a/examples/shape_batcher.rs
+++ b/examples/shape_batcher.rs
@@ -14,7 +14,7 @@ fn main() {
 
 struct App {
     total_time: Duration,
-    pipeline: Pipeline<util::BasicPipelineMeta>,
+    pipeline: util::BasicPipeline,
     batcher: util::ShapeBatcher,
     ctx: Rc<GlContext>,
 }
@@ -33,7 +33,7 @@ impl EventHandler<()> for App {
 
     fn init(ctx: Rc<GlContext>, _fs: Rc<dyn FsServer>, _init: ()) -> App {
         let batcher = util::ShapeBatcher::new_from_size(&ctx, 20_000, 20_000);
-        let pipeline = ctx.new_pipeline();
+        let pipeline = util::new_basic_pipeline(&ctx);
 
         App { pipeline, batcher, ctx, total_time: Duration::ZERO }
     }
@@ -131,15 +131,14 @@ impl App {
                     Mat4::orthographic_rh_gl(0.0, width as f32, height as f32, 0.0, 0.0, 1.0);
                 let num_elements = self.batcher.flush();
 
-                self.ctx.draw(DrawCall {
-                    pipeline: &self.pipeline,
-                    base_element: 0,
+                self.pipeline.draw(
+                    0,
                     num_elements,
-                    vertex_buffer: &self.batcher.0.vertices,
-                    index_buffer: &self.batcher.0.indicies,
-                    images: &NoImages,
-                    uniforms: &BasicPipelineUniforms { view_projection: proj },
-                });
+                    &self.batcher.0.vertices,
+                    &self.batcher.0.indicies,
+                    &NoImages,
+                    &BasicPipelineUniforms { view_projection: proj },
+                );
             });
     }
 }

--- a/examples/sprite_batch.rs
+++ b/examples/sprite_batch.rs
@@ -20,7 +20,7 @@ struct App {
     total_time: Duration,
     ctx: Rc<GlContext>,
 
-    pipeline: Pipeline<util::BasicSpritePipelineMeta>,
+    pipeline: util::BasicSpritePipeline,
     batcher: util::SpriteBatcher,
     texture: Option<Texture2D>,
 }
@@ -53,7 +53,7 @@ impl EventHandler<()> for App {
     fn init(ctx: Rc<GlContext>, fs_server: Rc<dyn FsServer>, _init: ()) -> App {
         fs_server.load_file(Path::new("assets/GB-Tileset.png"));
 
-        let pipeline = ctx.new_pipeline();
+        let pipeline = util::new_basic_sprite_pipeline(&ctx);
         let batcher = util::SpriteBatcher::new_from_size(&ctx, 2000);
 
         App { total_time: Duration::ZERO, batcher, pipeline, texture: None, ctx }
@@ -64,7 +64,7 @@ impl App {
     fn draw(&mut self) {
         let t = self.total_time.as_secs_f32();
 
-        let Some(texture) = self.texture.as_ref() else {
+        let Some(tex) = self.texture.as_ref() else {
             return;
         };
 
@@ -106,18 +106,17 @@ impl App {
                     transform: char_tf,
                 });
                 let num_elements = self.batcher.flush();
-                self.ctx.draw(DrawCall {
-                    pipeline: &self.pipeline,
-                    base_element: 0,
+                self.pipeline.draw(
+                    0,
                     num_elements,
-                    vertex_buffer: &self.batcher.0.vertices,
-                    index_buffer: &self.batcher.0.indicies,
-                    images: texture,
-                    uniforms: &BasicSpritePipelineUniforms {
+                    &self.batcher.0.vertices,
+                    &self.batcher.0.indicies,
+                    &util::BasicTexImages { tex },
+                    &BasicSpritePipelineUniforms {
                         view_projection,
-                        width_height: texture.size().as_vec2(),
+                        width_height: tex.size().as_vec2(),
                     },
-                });
+                );
             });
     }
 }

--- a/examples/timing.rs
+++ b/examples/timing.rs
@@ -18,7 +18,7 @@ fn main() {
 struct App {
     vertices_cube: VertexBuffer<CubeVert>,
     indicies_cube: IndexBuffer,
-    offscreen_pipeline: Pipeline<OffscreenMeta>,
+    offscreen_pipeline: Pipeline<CubeVert, Uniforms>,
     rx: f32,
     ry: f32,
 
@@ -82,7 +82,14 @@ impl EventHandler<()> for App {
             22, 21, 20,  23, 22, 20
         ]);
 
-        let offscreen_pipeline = ctx.new_pipeline();
+        let offscreen_pipeline = ctx.new_pipeline(
+            include_str!("shaders/mvp_color.vert"),
+            include_str!("shaders/basic_color.frag"),
+            PipelineParams {
+                depth_test: Some(Comparison::LessOrEqual),
+                ..default_pipeline_params()
+            },
+        );
 
         App { vertices_cube, indicies_cube, offscreen_pipeline, rx: 0., ry: 0., ctx }
     }
@@ -105,15 +112,14 @@ impl App {
         // the offscreen pass, rendering an rotating, untextured cube into a render target image
         self.ctx
             .default_pass(Clear::depth_color(Color::WHITE), |_, _| {
-                self.ctx.draw(DrawCall {
-                    pipeline: &self.offscreen_pipeline,
-                    base_element: 0,
-                    num_elements: 36,
-                    vertex_buffer: &self.vertices_cube,
-                    index_buffer: &self.indicies_cube,
-                    images: &NoImages,
-                    uniforms: &OffscreenUniforms { mvp: view_proj * model },
-                });
+                self.offscreen_pipeline.draw(
+                    0,
+                    36,
+                    &self.vertices_cube,
+                    &self.indicies_cube,
+                    &NoImages,
+                    &Uniforms { mvp: view_proj * model },
+                );
             });
     }
 }
@@ -142,26 +148,8 @@ impl Vertex for QuadVert {
         &[attribute_of!(QuadVert, v_pos), attribute_of!(QuadVert, v_uv)];
 }
 
-pub struct OffscreenMeta;
-
-impl PipelineMeta for OffscreenMeta {
-    const VERTEX_SHADER: &str = include_str!("shaders/mvp_color.vert");
-    const FRAGMENT_SHADER: &str = include_str!("shaders/basic_color.frag");
-
-    const IMAGES_NAMES: () = ();
-    type Images = NoImages;
-    type Vertex = CubeVert;
-    type Uniforms = OffscreenUniforms;
-    const PARAMS: PipelineParams =
-        PipelineParams { depth_test: Some(Comparison::LessOrEqual), ..default_pipeline_params() };
-}
-
 #[repr(C)]
-#[derive(Debug, Pod, Zeroable, Clone, Copy)]
-pub struct OffscreenUniforms {
+#[derive(Debug, Pod, Zeroable, Clone, Copy, UniformBlock)]
+pub struct Uniforms {
     pub mvp: glam::Mat4,
-}
-
-impl UniformBlock for OffscreenUniforms {
-    const FIELDS: &'static [UniformField] = &[uniform_of!(OffscreenUniforms, mvp)];
 }

--- a/examples/triangle.rs
+++ b/examples/triangle.rs
@@ -18,7 +18,7 @@ fn main() {
 }
 
 struct App {
-    pipeline: Pipeline<Meta>,
+    pipeline: Pipeline<TriangleVertex>,
     vertices: VertexBuffer<TriangleVertex>,
     indicies: IndexBuffer,
     ctx: Rc<GlContext>,
@@ -42,7 +42,11 @@ impl EventHandler<()> for App {
             TriangleVertex { v_pos: vec2(0.0,  0.5), v_color: Color::BLUE },
         ]);
         let indicies = ctx.new_index_buffer(BufferUsage::Immutable, &[0, 1, 2]);
-        let pipeline = ctx.new_pipeline();
+        let pipeline = ctx.new_pipeline(
+            include_str!("shaders/basic_vert.vert"),
+            include_str!("shaders/basic_color.frag"),
+            default_pipeline_params(),
+        );
 
         App { pipeline, indicies, vertices, ctx }
     }
@@ -52,15 +56,8 @@ impl App {
     pub fn draw(&mut self) {
         self.ctx
             .default_pass(Clear::depth_color(Color::BLACK), |_, _| {
-                self.ctx.draw(DrawCall {
-                    pipeline: &self.pipeline,
-                    base_element: 0,
-                    num_elements: 3,
-                    vertex_buffer: &self.vertices,
-                    index_buffer: &self.indicies,
-                    images: &NoImages,
-                    uniforms: &NoUniforms,
-                });
+                self.pipeline
+                    .draw(0, 3, &self.vertices, &self.indicies, &NoImages, &NoUniforms);
             });
     }
 }
@@ -70,17 +67,4 @@ impl App {
 pub struct TriangleVertex {
     pub v_pos: Vec2,
     pub v_color: Color,
-}
-
-pub struct Meta;
-
-impl PipelineMeta for Meta {
-    const VERTEX_SHADER: &str = include_str!("shaders/basic_vert.vert");
-    const FRAGMENT_SHADER: &str = include_str!("shaders/basic_color.frag");
-
-    const IMAGES_NAMES: () = ();
-    type Images = NoImages;
-    type Vertex = TriangleVertex;
-    type Uniforms = NoUniforms;
-    const PARAMS: PipelineParams = default_pipeline_params();
 }

--- a/examples/triangle_color4b.rs
+++ b/examples/triangle_color4b.rs
@@ -15,7 +15,7 @@ fn main() {
 }
 
 struct App {
-    pipeline: Pipeline<Meta>,
+    pipeline: Pipeline<TriangleVertex>,
     vertices: VertexBuffer<TriangleVertex>,
     indicies: IndexBuffer,
     ctx: Rc<GlContext>,
@@ -42,7 +42,11 @@ impl EventHandler<()> for App {
 
         let indicies = [0, 1, 2];
         let indicies = ctx.new_index_buffer(BufferUsage::Immutable, &indicies);
-        let pipeline = ctx.new_pipeline();
+        let pipeline = ctx.new_pipeline(
+            include_str!("shaders/basic_coloru8.vert"),
+            include_str!("shaders/basic_color.frag"),
+            default_pipeline_params(),
+        );
 
         App { pipeline, vertices, indicies, ctx }
     }
@@ -52,15 +56,8 @@ impl App {
     fn draw(&mut self) {
         self.ctx
             .default_pass(Clear::depth_color(Color::BLACK), |_, _| {
-                self.ctx.draw(DrawCall {
-                    pipeline: &self.pipeline,
-                    base_element: 0,
-                    num_elements: 3,
-                    vertex_buffer: &self.vertices,
-                    index_buffer: &self.indicies,
-                    images: &NoImages,
-                    uniforms: &NoUniforms,
-                });
+                self.pipeline
+                    .draw(0, 3, &self.vertices, &self.indicies, &NoImages, &NoUniforms);
             });
     }
 }
@@ -70,17 +67,4 @@ impl App {
 pub struct TriangleVertex {
     pub v_pos: Vec2,
     pub v_color: U8Vec4,
-}
-
-pub struct Meta;
-
-impl PipelineMeta for Meta {
-    const VERTEX_SHADER: &str = include_str!("shaders/basic_coloru8.vert");
-    const FRAGMENT_SHADER: &str = include_str!("shaders/basic_color.frag");
-
-    const IMAGES_NAMES: () = ();
-    type Images = NoImages;
-    type Vertex = TriangleVertex;
-    type Uniforms = NoUniforms;
-    const PARAMS: PipelineParams = default_pipeline_params();
 }

--- a/examples/triangle_verbose.rs
+++ b/examples/triangle_verbose.rs
@@ -22,7 +22,7 @@ fn main() {
 }
 
 struct App {
-    pipeline: Pipeline<Meta>,
+    pipeline: Pipeline<TriangleVertex>,
     vertices: VertexBuffer<TriangleVertex>,
     indicies: IndexBuffer,
     ctx: Rc<GlContext>,
@@ -46,7 +46,11 @@ impl EventHandler<()> for App {
             TriangleVertex { v_pos: vec2(0.0,  0.5), v_color: Color::BLUE },
         ]);
         let indicies = ctx.new_index_buffer(BufferUsage::Immutable, &[0, 1, 2]);
-        let pipeline = ctx.new_pipeline();
+        let pipeline = ctx.new_pipeline(
+            include_str!("shaders/basic_vert.vert"),
+            include_str!("shaders/basic_color.frag"),
+            default_pipeline_params(),
+        );
 
         App { pipeline, indicies, vertices, ctx }
     }
@@ -56,15 +60,8 @@ impl App {
     pub fn draw(&mut self) {
         self.ctx
             .default_pass(Clear::depth_color(Color::BLACK), |_, _| {
-                self.ctx.draw(DrawCall {
-                    pipeline: &self.pipeline,
-                    base_element: 0,
-                    num_elements: 3,
-                    vertex_buffer: &self.vertices,
-                    index_buffer: &self.indicies,
-                    images: &NoImages,
-                    uniforms: &NoUniforms,
-                });
+                self.pipeline
+                    .draw(0, 3, &self.vertices, &self.indicies, &NoImages, &NoUniforms);
             });
     }
 }
@@ -74,17 +71,4 @@ impl App {
 pub struct TriangleVertex {
     pub v_pos: Vec2,
     pub v_color: Color,
-}
-
-pub struct Meta;
-
-impl PipelineMeta for Meta {
-    const VERTEX_SHADER: &str = include_str!("shaders/basic_vert.vert");
-    const FRAGMENT_SHADER: &str = include_str!("shaders/basic_color.frag");
-
-    const IMAGES_NAMES: () = ();
-    type Images = NoImages;
-    type Vertex = TriangleVertex;
-    type Uniforms = NoUniforms;
-    const PARAMS: PipelineParams = default_pipeline_params();
 }

--- a/src/graphics/mod.rs
+++ b/src/graphics/mod.rs
@@ -122,8 +122,13 @@ impl GlContext {
     }
 
     #[track_caller]
-    pub fn new_pipeline<M: PipelineMeta>(self: &Rc<Self>) -> Pipeline<M> {
-        Pipeline::new(self.clone())
+    pub fn new_pipeline<V: Vertex, U: UniformBlock, I: ImagesUniformBlock>(
+        self: &Rc<Self>,
+        vert_shader: &str,
+        frag_shader: &str,
+        params: PipelineParams,
+    ) -> Pipeline<V, U, I> {
+        Pipeline::new(self.clone(), vert_shader, frag_shader, params)
     }
 
     pub fn new_render_pass(
@@ -132,40 +137,6 @@ impl GlContext {
         depth_img: Option<Texture2D>,
     ) -> RenderPass {
         RenderPass::new(self.clone(), color_img, depth_img)
-    }
-
-    #[track_caller]
-    pub fn draw<'a, M, I>(&'a self, drawcall: DrawCall<'a, M, I>)
-    where
-        M: PipelineMeta,
-        I: VertexIndex,
-    {
-        drawcall.pipeline.apply(
-            drawcall.vertex_buffer,
-            drawcall.index_buffer,
-            drawcall.images,
-            drawcall.uniforms,
-        );
-
-        let sz_elem = std::mem::size_of::<I>() as i32;
-        let offset = sz_elem * drawcall.base_element as i32;
-        let mode = match drawcall.pipeline.primitive_type() {
-            PrimitiveType::Triangles => glow::TRIANGLES,
-            PrimitiveType::Lines => glow::LINES,
-            PrimitiveType::Points => glow::POINTS,
-        };
-
-        unsafe {
-            self.gl.draw_elements_instanced(
-                mode,
-                drawcall.num_elements as i32,
-                I::GL_TYPE,
-                offset,
-                1,
-            );
-        }
-
-        self.check_no_gl_error();
     }
 
     #[cfg(debug_assertions)]
@@ -189,14 +160,4 @@ impl Drop for GlContext {
             self.gl.delete_vertex_array(self.vao);
         }
     }
-}
-
-pub struct DrawCall<'a, M: PipelineMeta, I: VertexIndex = u16> {
-    pub pipeline: &'a Pipeline<M>,
-    pub base_element: u32,
-    pub num_elements: u32,
-    pub vertex_buffer: &'a VertexBuffer<M::Vertex>,
-    pub index_buffer: &'a IndexBuffer<I>,
-    pub images: <M::Images as ImagesBlock>::Borrow<'a>,
-    pub uniforms: &'a M::Uniforms,
 }

--- a/src/graphics/pipeline.rs
+++ b/src/graphics/pipeline.rs
@@ -4,9 +4,9 @@ use std::rc::Rc;
 
 use crate::GLSL_VERSION;
 use crate::graphics::{
-    GlContext, ImagesBlock, IndexBuffer, PipelineParams, PrimitiveType, Texture2D, UniformBlock,
-    UniformField, Vertex, VertexBuffer, VertexField, VertexIndex, apply_attributes_impl,
-    apply_uniforms_impl,
+    GlContext, ImageUniformField, ImagesUniformBlock, IndexBuffer, NoImages, NoUniforms,
+    PipelineParams, PrimitiveType, UniformBlock, UniformField, Vertex, VertexBuffer, VertexField,
+    VertexIndex, apply_attributes_impl, apply_uniforms_impl,
 };
 
 use glow::HasContext;
@@ -14,33 +14,43 @@ use glow::HasContext;
 static TARGET_NAME: &str = "gl.pipeline";
 
 #[derive(Debug)]
-pub struct Pipeline<M: PipelineMeta> {
+pub struct Pipeline<V, U = NoUniforms, I = NoImages> {
     raw: PipelineRaw,
-    _phantom: PhantomData<M>,
+    _phantom: PhantomData<fn(&V, &U, &I)>,
 }
 
-impl<M: PipelineMeta> Pipeline<M> {
+impl<Vert, Uni, Img> Pipeline<Vert, Uni, Img>
+where
+    Vert: Vertex,
+    Uni: UniformBlock,
+    Img: ImagesUniformBlock,
+{
     #[track_caller]
-    pub fn new(ctx: Rc<GlContext>) -> Pipeline<M> {
+    pub fn new(
+        ctx: Rc<GlContext>,
+        vert_shader: &str,
+        frag_shader: &str,
+        params: PipelineParams,
+    ) -> Pipeline<Vert, Uni, Img> {
         debug_assert_eq!(
             Self::sz_vert_fields(),
-            std::mem::size_of::<M::Vertex>(),
+            std::mem::size_of::<Vert>(),
             "vertex layout mismatch",
         );
         debug_assert_eq!(
             Self::sz_uni_fields(),
-            std::mem::size_of::<M::Uniforms>(),
+            std::mem::size_of::<Uni>(),
             "uniform layout mismatch",
         );
 
         let raw = PipelineRaw::new(
             ctx,
-            M::VERTEX_SHADER,
-            M::FRAGMENT_SHADER,
-            M::PARAMS,
-            M::Images::names(&M::IMAGES_NAMES),
-            M::Vertex::LAYOUT,
-            M::Uniforms::FIELDS,
+            vert_shader,
+            frag_shader,
+            params,
+            Img::FIELDS,
+            Vert::LAYOUT,
+            Uni::FIELDS,
         );
         Pipeline { raw, _phantom: PhantomData }
     }
@@ -49,19 +59,45 @@ impl<M: PipelineMeta> Pipeline<M> {
         self.raw.params.primitive_type
     }
 
-    pub(crate) fn apply<'a, I: VertexIndex>(
+    pub fn draw<'a, Idx: VertexIndex>(
         &'a self,
-        vertex_buffer: &'a VertexBuffer<M::Vertex>,
-        index_buffer: &'a IndexBuffer<I>,
-        images: <M::Images as ImagesBlock>::Borrow<'a>,
-        uniforms: &'a M::Uniforms,
+        base_element: u32,
+        num_elements: u32,
+        vertex_buffer: &'a VertexBuffer<Vert>,
+        index_buffer: &'a IndexBuffer<Idx>,
+        images: Img::Borrow<'a>,
+        uniforms: &'a Uni,
     ) {
-        debug_assert_eq!(
-            M::Images::as_slice(&images).len(),
-            M::Images::names(&M::IMAGES_NAMES).len(),
-            "image inputs mismatch",
-        );
+        self.apply(vertex_buffer, index_buffer, images, uniforms);
 
+        let sz_elem = std::mem::size_of::<Idx>() as i32;
+        let offset = sz_elem * base_element as i32;
+        let mode = match self.primitive_type() {
+            PrimitiveType::Triangles => glow::TRIANGLES,
+            PrimitiveType::Lines => glow::LINES,
+            PrimitiveType::Points => glow::POINTS,
+        };
+
+        unsafe {
+            self.raw.ctx.gl.draw_elements_instanced(
+                mode,
+                num_elements as i32,
+                Idx::GL_TYPE,
+                offset,
+                1,
+            );
+        }
+
+        self.raw.ctx.check_no_gl_error();
+    }
+
+    pub(crate) fn apply<'a, Idx: VertexIndex>(
+        &'a self,
+        vertex_buffer: &'a VertexBuffer<Vert>,
+        index_buffer: &'a IndexBuffer<Idx>,
+        images: Img::Borrow<'a>,
+        uniforms: &'a Uni,
+    ) {
         tracing::trace!(
             target: TARGET_NAME,
             gl_prog = ?self.raw.gl_prog,
@@ -70,22 +106,22 @@ impl<M: PipelineMeta> Pipeline<M> {
             images = ?images,
             "applying bindings",
         );
+        Img::bind(images);
         self.raw.apply(
             vertex_buffer.gl_buf,
             index_buffer.gl_buf,
-            M::Images::as_slice(&images),
             bytemuck::bytes_of(uniforms),
-            M::Uniforms::FIELDS,
-            std::mem::size_of::<M::Vertex>(),
-            M::Vertex::LAYOUT,
+            Uni::FIELDS,
+            std::mem::size_of::<Vert>(),
+            Vert::LAYOUT,
         );
     }
 
     const fn sz_vert_fields() -> usize {
         let mut res = 0;
         let mut idx = 0;
-        while idx < M::Vertex::LAYOUT.len() {
-            res += M::Vertex::LAYOUT[idx].sz;
+        while idx < Vert::LAYOUT.len() {
+            res += Vert::LAYOUT[idx].sz;
             idx += 1;
         }
         res
@@ -94,24 +130,12 @@ impl<M: PipelineMeta> Pipeline<M> {
     const fn sz_uni_fields() -> usize {
         let mut res = 0;
         let mut idx = 0;
-        while idx < M::Uniforms::FIELDS.len() {
-            res += M::Uniforms::FIELDS[idx].sz;
+        while idx < Uni::FIELDS.len() {
+            res += Uni::FIELDS[idx].sz;
             idx += 1;
         }
         res
     }
-}
-
-pub trait PipelineMeta: 'static {
-    const VERTEX_SHADER: &'static str;
-    const FRAGMENT_SHADER: &'static str;
-
-    type Images: ImagesBlock;
-    const IMAGES_NAMES: <Self::Images as ImagesBlock>::Names;
-
-    type Vertex: Vertex;
-    type Uniforms: UniformBlock;
-    const PARAMS: PipelineParams;
 }
 
 #[derive(Debug)]
@@ -130,7 +154,7 @@ impl PipelineRaw {
         vertex: &str,
         fragment: &str,
         params: PipelineParams,
-        image_names: &[&str],
+        images: &[ImageUniformField],
         attributes: &[VertexField],
         uniforms: &[UniformField],
     ) -> PipelineRaw {
@@ -152,8 +176,8 @@ impl PipelineRaw {
 
         check_pipeline_attributes(&ctx.gl, gl_prog, attributes);
         let mut image_uniform_locs = Vec::new();
-        for image_name in image_names {
-            image_uniform_locs.push(get_uniform_location(&ctx.gl, gl_prog, image_name));
+        for image in images {
+            image_uniform_locs.push(get_uniform_location(&ctx.gl, gl_prog, image.name));
         }
         let mut uniform_locs = Vec::new();
         for uniform in uniforms {
@@ -168,7 +192,6 @@ impl PipelineRaw {
         &self,
         vertex_buffer: glow::Buffer,
         index_buffer: glow::Buffer,
-        images: &[&Texture2D],
         uniform_data: &[u8],
         uniform_layout: &[UniformField],
         attribute_size: usize,
@@ -188,9 +211,8 @@ impl PipelineRaw {
         cache.set_color_write(&self.ctx.gl, self.params.color_write);
         self.ctx.check_no_gl_error();
 
-        for (n, (image_loc, texture)) in self.image_uniform_locs.iter().zip(images).enumerate() {
+        for (n, image_loc) in self.image_uniform_locs.iter().enumerate() {
             unsafe {
-                cache.bind_texture(&self.ctx.gl, n as u32, glow::TEXTURE_2D, texture.gl_tex);
                 self.ctx.gl.uniform_1_i32(Some(image_loc), n as i32);
             }
         }

--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -179,7 +179,7 @@ fn create_and_bind_texture(
         );
     }
 
-    apply_texture_parameters(&ctx, wrap, min_filter, mag_filter);
+    apply_texture_parameters(ctx, wrap, min_filter, mag_filter);
     ctx.check_no_gl_error();
 
     gl_tex

--- a/src/graphics/texture.rs
+++ b/src/graphics/texture.rs
@@ -5,7 +5,7 @@ use glow::{HasContext, PixelUnpackData};
 use image::DynamicImage;
 use image::metadata::Orientation;
 
-use crate::graphics::GlContext;
+use crate::graphics::{GlContext, ImageUniformVal};
 
 static TARGET_NAME: &str = "gl.texture";
 
@@ -234,5 +234,14 @@ fn gl_texture_format(format: Texture2DFormat) -> (u32, u32, u32) {
             glow::UNSIGNED_SHORT,
         ),
         Texture2DFormat::DepthF32 => (glow::DEPTH_COMPONENT32F, glow::DEPTH_COMPONENT, glow::FLOAT),
+    }
+}
+
+impl ImageUniformVal for Texture2D {
+    const GL_TYPE: u32 = glow::TEXTURE_2D;
+
+    fn bind(&self, slot: u32) {
+        let mut cache = self.ctx.cache.borrow_mut();
+        cache.bind_texture(&self.ctx.gl, slot, Self::GL_TYPE, self.gl_tex);
     }
 }

--- a/src/graphics/ty/images.rs
+++ b/src/graphics/ty/images.rs
@@ -1,53 +1,47 @@
 use std::fmt::Debug;
 
-use crate::graphics::Texture2D;
-
 #[derive(Debug)]
 pub struct NoImages;
 
-impl ImagesBlock for NoImages {
-    type Names = ();
+impl ImagesUniformBlock for NoImages {
+    const FIELDS: &[ImageUniformField] = &[];
+
     type Borrow<'a> = &'a Self;
 
-    fn as_slice<'a, 'b>(_x: &'b Self::Borrow<'a>) -> &'b [&'a Texture2D] {
-        &[]
-    }
-
-    fn names(_x: &()) -> &'static [&'static str] {
-        &[]
+    fn bind(_raw: Self::Borrow<'_>) { /* NOOP */
     }
 }
 
-impl ImagesBlock for Texture2D {
-    type Names = &'static str;
-    type Borrow<'a> = &'a Texture2D;
-
-    fn as_slice<'a, 'b>(x: &'b Self::Borrow<'a>) -> &'b [&'a Texture2D] {
-        std::slice::from_ref(x)
-    }
-
-    fn names<'a>(x: &'a &'static str) -> &'a [&'static str] {
-        std::slice::from_ref(x)
-    }
+#[macro_export]
+macro_rules! image_uniform_of {
+    ($Type:path, $field:tt) => {{
+        $crate::graphics::ImageUniformField {
+            name: stringify!($field),
+            gl_type: $crate::graphics::gl_type_of_image_uniform_val::<$Type>(),
+        }
+    }};
 }
 
-impl<const N: usize> ImagesBlock for [Texture2D; N] {
-    type Names = &'static [&'static str; N];
-    type Borrow<'a> = &'a [&'a Texture2D; N];
+pub trait ImagesUniformBlock {
+    const FIELDS: &'static [ImageUniformField];
 
-    fn as_slice<'a, 'b>(x: &'b Self::Borrow<'a>) -> &'b [&'a Texture2D] {
-        x.as_slice()
-    }
+    type Borrow<'a>: Debug + Copy;
 
-    fn names(x: &Self::Names) -> &[&'static str] {
-        x.as_slice()
-    }
+    fn bind(raw: Self::Borrow<'_>);
 }
 
-pub trait ImagesBlock {
-    type Names;
-    type Borrow<'a>: Debug;
+#[derive(Debug, Clone, Copy)]
+pub struct ImageUniformField {
+    pub name: &'static str,
+    pub gl_type: u32,
+}
 
-    fn as_slice<'a, 'b>(x: &'b Self::Borrow<'a>) -> &'b [&'a Texture2D];
-    fn names(x: &Self::Names) -> &[&'static str];
+pub trait ImageUniformVal: Debug {
+    const GL_TYPE: u32;
+
+    fn bind(&self, slot: u32);
+}
+
+pub const fn gl_type_of_image_uniform_val<T: ImageUniformVal>() -> u32 {
+    T::GL_TYPE
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,9 +86,8 @@ impl<I, T: EventHandler<I>> ApplicationHandler<AppEvent> for App<I, T> {
     }
 
     fn new_events(&mut self, event_loop: &ActiveEventLoop, cause: StartCause) {
-        match cause {
-            StartCause::Init => event_loop.set_control_flow(ControlFlow::Wait),
-            _ => (),
+        if cause == StartCause::Init {
+            event_loop.set_control_flow(ControlFlow::Wait);
         }
     }
 

--- a/src/util/basic_pipeline.rs
+++ b/src/util/basic_pipeline.rs
@@ -1,23 +1,20 @@
+use std::rc::Rc;
+
 use bytemuck::{Pod, Zeroable};
 use glam::Mat4;
 
-use crate::graphics::{
-    NoImages, PipelineMeta, PipelineParams, UniformBlock, UniformField, default_pipeline_params,
-};
+use crate::graphics::{GlContext, Pipeline, UniformBlock, UniformField, default_pipeline_params};
 use crate::uniform_of;
 use crate::util::BasicVertex;
 
-pub struct BasicPipelineMeta;
+pub type BasicPipeline = Pipeline<BasicVertex, BasicPipelineUniforms>;
 
-impl PipelineMeta for BasicPipelineMeta {
-    const VERTEX_SHADER: &str = include_str!("shader/basic_pipeline.vert");
-    const FRAGMENT_SHADER: &str = include_str!("shader/basic_pipeline.frag");
-
-    const IMAGES_NAMES: () = ();
-    type Images = NoImages;
-    type Vertex = BasicVertex;
-    type Uniforms = BasicPipelineUniforms;
-    const PARAMS: PipelineParams = default_pipeline_params();
+pub fn new_basic_pipeline(ctx: &Rc<GlContext>) -> BasicPipeline {
+    ctx.new_pipeline(
+        include_str!("shader/basic_pipeline.vert"),
+        include_str!("shader/basic_pipeline.frag"),
+        default_pipeline_params(),
+    )
 }
 
 #[repr(C)]

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -14,7 +14,10 @@ use bytemuck::{Pod, Zeroable};
 use glam::Vec2;
 
 use crate::attribute_of;
-use crate::graphics::{Color, Vertex, VertexField};
+use crate::graphics::{
+    Color, ImageUniformField, ImageUniformVal, ImagesUniformBlock, Texture2D, Vertex, VertexField,
+};
+use crate::image_uniform_of;
 
 #[derive(Debug, Default, Pod, Zeroable, Clone, Copy)]
 #[repr(C)]
@@ -26,4 +29,19 @@ pub struct BasicVertex {
 impl Vertex for BasicVertex {
     const LAYOUT: &'static [VertexField] =
         &[attribute_of!(BasicVertex, v_pos), attribute_of!(BasicVertex, v_color)];
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct BasicTexImages<'a> {
+    pub tex: &'a Texture2D,
+}
+
+impl ImagesUniformBlock for BasicTexImages<'_> {
+    const FIELDS: &'static [ImageUniformField] = &[image_uniform_of!(Texture2D, tex)];
+
+    type Borrow<'a> = &'a BasicTexImages<'a>;
+
+    fn bind(raw: Self::Borrow<'_>) {
+        raw.tex.bind(0);
+    }
 }

--- a/src/util/sprite_batcher.rs
+++ b/src/util/sprite_batcher.rs
@@ -3,10 +3,10 @@ use std::rc::Rc;
 use bytemuck::{Pod, Zeroable};
 use glam::{Affine2, Mat4, UVec2, Vec2, vec2};
 
+use super::BasicTexImages;
 use crate::graphics::{
-    BlendEquation, BlendFactor, BlendFunc, BlendValue, Blending, GlContext, PipelineMeta,
-    PipelineParams, Texture2D, UniformBlock, UniformField, Vertex, VertexField,
-    default_pipeline_params,
+    BlendEquation, BlendFactor, BlendFunc, BlendValue, Blending, GlContext, Pipeline,
+    PipelineParams, UniformBlock, UniformField, Vertex, VertexField, default_pipeline_params,
 };
 use crate::util::GeometryBatcher;
 use crate::{attribute_of, uniform_of};
@@ -93,25 +93,22 @@ impl Vertex for SpriteVertex {
         &[attribute_of!(SpriteVertex, v_pos), attribute_of!(SpriteVertex, v_uv_not_normalized)];
 }
 
-pub struct BasicSpritePipelineMeta;
+pub type BasicSpritePipeline =
+    Pipeline<SpriteVertex, BasicSpritePipelineUniforms, BasicTexImages<'static>>;
 
-impl PipelineMeta for BasicSpritePipelineMeta {
-    const VERTEX_SHADER: &str = include_str!("shader/basic_sprite.vert");
-    const FRAGMENT_SHADER: &str = include_str!("shader/basic_sprite.frag");
-
-    type Images = Texture2D;
-    const IMAGES_NAMES: &str = "tex";
-
-    type Vertex = SpriteVertex;
-    type Uniforms = BasicSpritePipelineUniforms;
-    const PARAMS: PipelineParams = PipelineParams {
-        blending: Blending::All(BlendFunc {
-            equation: BlendEquation::Add,
-            source: BlendFactor::Value(BlendValue::SrcAlpha),
-            dest: BlendFactor::OneMinusValue(BlendValue::SrcAlpha),
-        }),
-        ..default_pipeline_params()
-    };
+pub fn new_basic_sprite_pipeline(ctx: &Rc<GlContext>) -> BasicSpritePipeline {
+    ctx.new_pipeline(
+        include_str!("shader/basic_sprite.vert"),
+        include_str!("shader/basic_sprite.frag"),
+        PipelineParams {
+            blending: Blending::All(BlendFunc {
+                equation: BlendEquation::Add,
+                source: BlendFactor::Value(BlendValue::SrcAlpha),
+                dest: BlendFactor::OneMinusValue(BlendValue::SrcAlpha),
+            }),
+            ..default_pipeline_params()
+        },
+    )
 }
 
 #[repr(C)]


### PR DESCRIPTION
Reduce the amount of boilerplate needed to make pipelines.
With these changes, pipelines are faster to alter, while keeping the whole type-safe thing.